### PR TITLE
feat: Streamlined redis stream creation

### DIFF
--- a/consumer.py
+++ b/consumer.py
@@ -1,15 +1,42 @@
-from main import redis, Order
+from redis_om import get_redis_connection, HashModel
+from dotenv import load_dotenv
+import os
 import time
+
+load_dotenv()
 
 key = "refund_order"
 group = "payment-group"
 
-try:
-    redis.xgroup_create(key, group)
-except:
-    print("Group already exists, skipping creation")
 
-while True:
+
+redis = get_redis_connection(
+    host=os.getenv("REDIS_HOST", "localhost"),
+    port=int(os.getenv("REDIS_PORT", 6379)),
+    db=int(os.getenv("REDIS_DB", 0)),
+    decode_responses=True
+)
+
+class Order(HashModel):
+    product_id: str
+    quantity: int
+    price: float
+    fee: float
+    total: float
+    status: str
+
+    class Meta:
+        database = redis
+        model_key_prefix = "order"
+
+def create_redis_group(key, group):
+    try:
+        redis.xgroup_create(key, group, mkstream=True)
+        print(f"Redis group '{group}' created for key '{key}'")
+    except Exception as e:
+        print(f"Failed to create Redis group '{group}' for key '{key}': {str(e)}")
+
+def read_from_redis_group(group, key):
     try:
         results = redis.xreadgroup(group, key, {key: ">"}, None)
         
@@ -23,6 +50,14 @@ while True:
                 print(f"Order {obj['pk']} refunded.")
                 
     except Exception as e:
-        print(str(e))
+        print(f"Failed to read from Redis group '{group}' for key '{key}': {str(e)}")
 
-    time.sleep(5)
+def main():
+    create_redis_group(key, group)
+
+    while True:
+        read_from_redis_group(group, key)
+        time.sleep(5)
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ class Order(HashModel):
 
     class Meta:
         database = redis
+        model_key_prefix = "order"
 
 def format_order(pk: str):
     order = Order.get(pk)


### PR DESCRIPTION
- Rewrote the consumer script to be modular, with all necessary functionality built-in, as I would like to run it as a different pod in my k8s cluster.
- With [mkstream](https://redis-py.readthedocs.io/en/stable/commands.html#redis.commands.core.CoreCommands.xgroup_create) parameter set to true, Redis would automatically create a stream with length of 0 if it does not exist.
